### PR TITLE
docs(readme): add live demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Live Demo
+https://ecommerce-project-two-xi.vercel.app/
+
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
Added a direct link to the live Vercel deployment in the README for easier access and testing. No functional or code changes were made.